### PR TITLE
ESP8266 ctype.h workaround

### DIFF
--- a/src/unabto/unabto_common_main.c
+++ b/src/unabto/unabto_common_main.c
@@ -30,7 +30,9 @@
 #include "unabto_tcp_fallback.h"
 
 #include <string.h>
+#ifndef ESP8266
 #include <ctype.h>
+#endif
 
 #if UNABTO_PLATFORM_PIC18
 #pragma udata big_mem

--- a/src/unabto/unabto_common_main.c
+++ b/src/unabto/unabto_common_main.c
@@ -30,9 +30,6 @@
 #include "unabto_tcp_fallback.h"
 
 #include <string.h>
-#ifndef ESP8266
-#include <ctype.h>
-#endif
 
 #if UNABTO_PLATFORM_PIC18
 #pragma udata big_mem
@@ -123,7 +120,7 @@ nabto_main_setup* unabto_init_context(void) {
 
 bool unabto_init(void) {
     if (!checkValidDeviceId(nmc.nabtoMainSetup.id)) {
-        NABTO_LOG_FATAL(("%s is not a valid device id, uppercase letters are not allowed in a device id.", nmc.nabtoMainSetup.id));
+        NABTO_LOG_FATAL(("%s is not a valid device id, only \"a\" to \"z\", \"0\" to \"9\", hyphen (\"-\") and period (\".\") are allowed in a device id.", nmc.nabtoMainSetup.id));
         return false;
     }
 
@@ -367,7 +364,7 @@ void unabto_notify_ip_changed(uint32_t ip) {
 static bool checkValidDeviceId(const char* id) {
     while(*id)
     {
-        if(isupper(*id))
+        if(!((*id >= 'a' && *id <= 'z') || (*id >= '0' && *id <= '9') || *id == '-' || *id == '.')) 
         {
             NABTO_LOG_TRACE(("%c is not a valid device name character", *id));
             return false;


### PR DESCRIPTION
The official ESP8266 board package for the Arduino IDE fails to build when including `ctype.h` in `unabto_common_main.c` with the following error:

```
/tmp/build92e4df0649327d06699101ac83054a11.tmp/libraries/unabto-esp8266-sdk/unabto/unabto_common_main.c.o: In function `unabto_init_context':
/home/cs/Arduino/libraries/unabto-esp8266-sdk/src/unabto/unabto_common_main.c:240: undefined reference to `__ctype_ptr__'
collect2: error: ld returned 1 exit status
```

The easiest workaround is to remove the include (`isupper()` still works). Also, the `ESP8266` switch shouldn't interfere with any other platform.