### PR TITLE
Openssl 1.1.0fix

### DIFF
--- a/src/modules/crypto/openssl/unabto_crypto_openssl.c
+++ b/src/modules/crypto/openssl/unabto_crypto_openssl.c
@@ -82,7 +82,15 @@ void unabto_hmac_sha256_buffers(const buffer_t keys[], uint8_t keys_size,
     }
 
     uint8_t hash[EVP_MAX_MD_SIZE];
-    HMAC_CTX* ctx = HMAC_CTX_new();
+
+    HMAC_CTX* ctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    HMAC_CTX ctxData;
+    ctx = &ctxData;
+    HMAC_CTX_init(ctx);
+#else
+    ctx = HMAC_CTX_new();
+#endif
     if (ctx == NULL) {
         NABTO_LOG_ERROR(("cannot allocate hmac ctx"));
     }
@@ -103,5 +111,9 @@ void unabto_hmac_sha256_buffers(const buffer_t keys[], uint8_t keys_size,
     }
 
     memcpy(mac, hash, MIN(mac_size, hash_size));
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    HMAC_CTX_cleanup(ctx);
+#else
     HMAC_CTX_free(ctx);
+#endif
 }

--- a/src/modules/crypto/openssl/unabto_crypto_openssl.c
+++ b/src/modules/crypto/openssl/unabto_crypto_openssl.c
@@ -12,37 +12,45 @@
 
 bool aes128_cbc_encrypt(const uint8_t* key, uint8_t* input, uint16_t input_len)
 {
-    EVP_CIPHER_CTX ctx;
-    EVP_CIPHER_CTX_init(&ctx);
-    if (EVP_EncryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL, key, input /* first 16 bytes of the input is the iv */) == 0) {
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        NABTO_LOG_ERROR(("cannot allocate cipher ctx"));
+    }
+    EVP_CIPHER_CTX_init(ctx);
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, input /* first 16 bytes of the input is the iv */) == 0) {
         NABTO_LOG_ERROR(("EVP_EncryptInit_ex should return 1"));
     }
 
     int outLength;
-    if(EVP_EncryptUpdate(&ctx, input+16, &outLength, input+16, input_len-16) != 1) {
+    if(EVP_EncryptUpdate(ctx, input+16, &outLength, input+16, input_len-16) != 1) {
         NABTO_LOG_ERROR(("EVP_EncryptUpdate should return 1"));
     }
-    if(EVP_CIPHER_CTX_cleanup(&ctx) != 1) {
+    if(EVP_CIPHER_CTX_cleanup(ctx) != 1) {
         NABTO_LOG_ERROR(("EVP_CIPHER_CTX_cleanup should return 1"));
     }
+    EVP_CIPHER_CTX_free(ctx);
     return true;
 }
 
 bool aes128_cbc_decrypt(const uint8_t* key, uint8_t* input, uint16_t input_len)
 {
-    EVP_CIPHER_CTX ctx;
-    EVP_CIPHER_CTX_init(&ctx);
-    if (EVP_DecryptInit_ex(&ctx, EVP_aes_128_cbc(), NULL, key, input /* iv is the first 16 bytes*/) != 1) {
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        NABTO_LOG_ERROR(("cannot allocate cipher ctx"));
+    }
+    EVP_CIPHER_CTX_init(ctx);
+    if (EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, input /* iv is the first 16 bytes*/) != 1) {
         NABTO_LOG_ERROR(("EVP_DecryptInit_ex should return 1"));
     }
     
     int outLength;
-    if (EVP_DecryptUpdate(&ctx, input+16, &outLength, input+16, input_len-16) != 1) {
+    if (EVP_DecryptUpdate(ctx, input+16, &outLength, input+16, input_len-16) != 1) {
         NABTO_LOG_ERROR(("EVP_DecryptUpdate should return 1"));
     }
-    if (EVP_CIPHER_CTX_cleanup(&ctx) != 1) {
+    if (EVP_CIPHER_CTX_cleanup(ctx) != 1) {
         NABTO_LOG_ERROR(("EVP_CIPHER_CTX_cleanup should return 1"));
     }
+    EVP_CIPHER_CTX_free(ctx);
     return true;
 }
 
@@ -74,24 +82,26 @@ void unabto_hmac_sha256_buffers(const buffer_t keys[], uint8_t keys_size,
     }
 
     uint8_t hash[EVP_MAX_MD_SIZE];
-    HMAC_CTX ctx;
-    HMAC_CTX_init(&ctx);
+    HMAC_CTX* ctx = HMAC_CTX_new();
+    if (ctx == NULL) {
+        NABTO_LOG_ERROR(("cannot allocate hmac ctx"));
+    }
     
-    if (HMAC_Init_ex(&ctx, key, key_size, EVP_sha256(), NULL) != 1) {
+    if (HMAC_Init_ex(ctx, key, key_size, EVP_sha256(), NULL) != 1) {
         NABTO_LOG_ERROR(("HMAC_Init_ex should return 1"));
     }
 
     for (i = 0; i < messages_size; i++) {
-        if (HMAC_Update(&ctx, messages[i].data, messages[i].size) != 1) {
+        if (HMAC_Update(ctx, messages[i].data, messages[i].size) != 1) {
             NABTO_LOG_ERROR(("HMAC_Update should return 1"));
         }
     }
 
     unsigned int hash_size;
-    if (HMAC_Final(&ctx, hash, &hash_size) != 1) {
+    if (HMAC_Final(ctx, hash, &hash_size) != 1) {
         NABTO_LOG_ERROR(("HMAC_Final should return 1"));
     }
 
     memcpy(mac, hash, MIN(mac_size, hash_size));
-    HMAC_CTX_cleanup(&ctx);
+    HMAC_CTX_free(ctx);
 }


### PR DESCRIPTION
openssl 1.1.0 makes most contexts opaque, this requires small changes to the existing openssl code