### PR TITLE
add acl check when opening tunnel

### DIFF
--- a/apps/axis/src/axis.c
+++ b/apps/axis/src/axis.c
@@ -101,3 +101,7 @@ application_event_result application_poll(application_request* applicationReques
 
 void application_poll_drop(application_request* applicationRequest) {
 }
+
+bool unabto_tunnel_allow_client_access(nabto_connect* connection) {
+    return true;
+}

--- a/apps/multi_tunnel/src/main.c
+++ b/apps/multi_tunnel/src/main.c
@@ -483,3 +483,7 @@ application_event_result application_poll(application_request* applicationReques
 
 void application_poll_drop(application_request* applicationRequest) {
 }
+
+bool unabto_tunnel_allow_client_access(nabto_connect* connection) {
+    return true;
+}

--- a/apps/tunnel/src/custom_main.c
+++ b/apps/tunnel/src/custom_main.c
@@ -50,7 +50,7 @@ bool allow_client_access(nabto_connect* connection) {
     return false;
 }
 
-bool allow_client_tunnel(nabto_connect* connection) {
+bool unabto_tunnel_allow_client_access(nabto_connect* connection) {
     // see allow_client_access in main.c for example of an implementation that uses the FP ACL module
     return false;
 }

--- a/apps/tunnel/src/custom_main.c
+++ b/apps/tunnel/src/custom_main.c
@@ -49,3 +49,8 @@ bool allow_client_access(nabto_connect* connection) {
     // see allow_client_access in main.c for example of an implementation that uses the FP ACL module
     return false;
 }
+
+bool allow_client_tunnel(nabto_connect* connection) {
+    // see allow_client_access in main.c for example of an implementation that uses the FP ACL module
+    return false;
+}

--- a/apps/tunnel/src/main.c
+++ b/apps/tunnel/src/main.c
@@ -128,7 +128,6 @@ static bool tunnel_parse_args(int argc, char* argv[], nabto_main_setup* nms) {
     const char x12s[] = "s";     const char* x12l[] = { "dummy-key", 0 };
     const char x13s[] = "k";     const char* x13l[] = { "encryption-key", 0 };
     const char x14s[] = "p";     const char* x14l[] = { "localport", 0 };
-    const char x15s[] = "a";     const char* x15l[] = { "check-acl", 0 };
     const char x16s[] = "";      const char* x16l[] = { "allow-port", 0};
     const char x17s[] = "";      const char* x17l[] = { "allow-host", 0};
     const char x18s[] = "x";     const char* x18l[] = { "nice-exit", 0};
@@ -334,7 +333,7 @@ static bool tunnel_parse_args(int argc, char* argv[], nabto_main_setup* nms) {
             ports[i] = atoi(opt);
         }
     } else {
-        NABTO_LOG_FATAL(("You did not allow client to connect to any ports, specify with '--allow_port'. Try -h for help."));
+        NABTO_LOG_FATAL(("You did not allow client to connect to any ports, specify with '--allow-port'. Try -h for help."));
     }
     
     hosts_length = gopt(options, ALLOW_HOST_OPTION);
@@ -489,7 +488,7 @@ bool allow_client_access(nabto_connect* connection) {
     }
 }
 
-bool allow_client_tunnel(nabto_connect* connection) {
+bool unabto_tunnel_allow_client_access(nabto_connect* connection) {
     if (no_access_control) {
         return true;
     } else {

--- a/apps/tunnel/src/main.c
+++ b/apps/tunnel/src/main.c
@@ -211,6 +211,7 @@ static bool tunnel_parse_args(int argc, char* argv[], nabto_main_setup* nms) {
         printf("  -P, --tunnel-default-port   Set default port for tunnel (%u).\n", UNABTO_TUNNEL_TCP_DEFAULT_PORT);
         printf("  -k, --encryption-key        Specify encryption key.\n");
         printf("  -s, --dummy-key             Use dummy key (for testing only).\n");
+        printf("      --no-crypto             Disable crypto (requires special basestation and client).\n");
         printf("  -p, --localport             Specify port for local connections.\n");
         printf("  -A, --controller            Specify controller address\n");
         printf("      --controller-port       sets the controller port number.\n");
@@ -220,7 +221,6 @@ static bool tunnel_parse_args(int argc, char* argv[], nabto_main_setup* nms) {
         printf("      --allow-all-hosts       Allow connections to all TCP hosts.\n");
         printf("      --no-access-control     Do not enforce client access control on incoming connections. \n");
         printf("  -x, --nice-exit             Close the tunnels nicely when pressing Ctrl+C.\n");
-        printf("      --no-crypto             Disable crypto (requires special basestation and client).\n");
 #if NABTO_ENABLE_TCP_FALLBACK
         printf("      --disable-tcp-fb        Disable tcp fallback.\n");
 #endif
@@ -483,9 +483,18 @@ bool allow_client_access(nabto_connect* connection) {
     if (no_access_control) {
         return true;
     } else {
-        bool local = connection->isLocal;
         bool allow = fp_acl_is_connection_allowed(connection);
-        NABTO_LOG_INFO(("Allowing %s connect request: %s", (local ? "local" : "remote"), (allow ? "yes" : "no")));
+        NABTO_LOG_INFO(("Allowing %s connect request: %s", (connection->isLocal ? "local" : "remote"), (allow ? "yes" : "no")));
+        return allow;
+    }
+}
+
+bool allow_client_tunnel(nabto_connect* connection) {
+    if (no_access_control) {
+        return true;
+    } else {
+        bool allow = fp_acl_is_tunnel_allowed(connection, FP_ACL_PERMISSION_NONE);
+        NABTO_LOG_INFO(("Allowing %s tunnel open request: %s", (connection->isLocal ? "local" : "remote"), (allow ? "yes" : "no")));
         return allow;
     }
 }

--- a/apps/tunnel/unabto_config.h
+++ b/apps/tunnel/unabto_config.h
@@ -4,6 +4,7 @@
 #include <modules/log/dynamic/unabto_dynamic_log.h>
 
 #define NABTO_ENABLE_CONNECTION_ESTABLISHMENT_ACL_CHECK 1
+#define NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK 1
 
 #define NABTO_ENABLE_STREAM 1
 #define NABTO_STREAM_MAX_STREAMS 16

--- a/src/modules/fingerprint_acl/fp_acl_ae.c
+++ b/src/modules/fingerprint_acl/fp_acl_ae.c
@@ -465,19 +465,29 @@ application_event_result fp_acl_ae_system_set_acl_settings(application_request* 
 
 
 // Helper function
-bool fp_acl_is_request_allowed(application_request* request, uint32_t requiredPermissions)
+bool fp_acl_is_user_allowed(nabto_connect* connection, uint32_t requiredPermissions)
 {
-    if (! (request->connection && request->connection->hasFingerprint)) {
+    if (! (connection && connection->hasFingerprint)) {
         return false;
     }
     
     struct fp_acl_user user;
-    void* it = aclDb.find(request->connection->fingerprint);
+    void* it = aclDb.find(connection->fingerprint);
     if (it == NULL || aclDb.load(it, &user) != FP_ACL_DB_OK) {
         return false;
     }
 
-    return fp_acl_check_user_permissions(&user, request->isLocal, requiredPermissions);
+    return fp_acl_check_user_permissions(&user, connection->isLocal, requiredPermissions);
+}
+
+bool fp_acl_is_request_allowed(application_request* request, uint32_t requiredPermissions)
+{
+    return fp_acl_is_user_allowed(request->connection, requiredPermissions);
+}
+
+bool fp_acl_is_tunnel_allowed(nabto_connect* connection, uint32_t requiredPermissions)
+{
+    return fp_acl_is_user_allowed(connection, requiredPermissions);
 }
 
 bool fp_acl_is_pair_allowed(application_request* request)
@@ -537,6 +547,7 @@ bool fp_acl_is_connection_allowed(nabto_connect* connection)
     }
     return true;
 }
+
 
 bool fp_acl_is_user_owner(application_request* request)
 {

--- a/src/modules/fingerprint_acl/fp_acl_ae.h
+++ b/src/modules/fingerprint_acl/fp_acl_ae.h
@@ -26,6 +26,11 @@ void fp_acl_ae_init(struct fp_acl_db* db);
 bool fp_acl_is_request_allowed(application_request* request, uint32_t requiredPermissions);
 
 /**
+ * call this function when opening a tunnel to check that sufficient permissions is present 
+ */
+bool fp_acl_is_tunnel_allowed(nabto_connect* connection, uint32_t requiredPermissions);
+
+/**
  * call this function to see if the given application
  * requets/connection is allowed to pair with the device.
  */

--- a/src/modules/tunnel/unabto_tunnel_common.c
+++ b/src/modules/tunnel/unabto_tunnel_common.c
@@ -1,4 +1,4 @@
-
+#include <unabto/unabto_app.h>
 #include <unabto/unabto_stream.h>
 #include <unabto/unabto_memory.h>
 #include <errno.h>
@@ -49,6 +49,13 @@ void unabto_tunnel_deinit_tunnels()
 }
 
 void unabto_tunnel_stream_accept(unabto_stream* stream) {
+#if NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
+    nabto_connect* con = unabto_stream_connection(stream);
+    if (!con || !allow_client_tunnel(con)) {
+        unabto_stream_close(stream);
+        return;
+    }
+#endif
     tunnel* t = &tunnels[unabto_stream_index(stream)];
     NABTO_LOG_TRACE(("Accepting stream and assigning it to tunnel %i", t));
     UNABTO_ASSERT(t->state == TS_IDLE);

--- a/src/modules/tunnel/unabto_tunnel_common.c
+++ b/src/modules/tunnel/unabto_tunnel_common.c
@@ -49,20 +49,23 @@ void unabto_tunnel_deinit_tunnels()
 }
 
 void unabto_tunnel_stream_accept(unabto_stream* stream) {
-#if NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
+    bool allowTunnel = false;
     nabto_connect* con = unabto_stream_connection(stream);
-    if (!con || !allow_client_tunnel(con)) {
-        unabto_stream_close(stream);
-        return;
+    if (con && unabto_tunnel_allow_client_access(con)) {
+        allowTunnel = true;
     }
-#endif
+
     tunnel* t = &tunnels[unabto_stream_index(stream)];
     NABTO_LOG_TRACE(("Accepting stream and assigning it to tunnel %i", t));
     UNABTO_ASSERT(t->state == TS_IDLE);
     unabto_tunnel_reset_tunnel_struct(t);
 
     t->stream = stream;
-    t->state = TS_READ_COMMAND;
+    if (allowTunnel) {
+        t->state = TS_READ_COMMAND;
+    } else {
+        t->state = TS_CLOSING;
+    }
     t->tunnelId = tunnelCounter++;
 }
 
@@ -73,11 +76,8 @@ tunnel* unabto_tunnel_get_tunnel(unabto_stream* stream)
     return t;
 }
 
-
-
 void unabto_tunnel_event(tunnel* tunnel, tunnel_event_source event_source)
 {
-    
     NABTO_LOG_TRACE(("Tunnel event on tunnel %i, source %i", tunnel->tunnelId, event_source));
     if (tunnel->state == TS_IDLE) {
         unabto_tunnel_idle(tunnel, event_source);
@@ -93,7 +93,7 @@ void unabto_tunnel_event(tunnel* tunnel, tunnel_event_source event_source)
     }
 
     if (tunnel->state == TS_FAILED_COMMAND) {
-        unabto_tunnel_failed_command(tunnel, event_source);
+        unabto_tunnel_closing(tunnel, event_source);
     }
     
     if (tunnel->state >= TS_PARSE_COMMAND) {
@@ -177,9 +177,9 @@ void unabto_tunnel_parse_command(tunnel* tunnel, tunnel_event_source tunnel_even
 }
 
 
-void unabto_tunnel_failed_command(tunnel* tunnel, tunnel_event_source tunnel_event)
+void unabto_tunnel_closing(tunnel* tunnel, tunnel_event_source tunnel_event)
 {
-    if (tunnel->state == TS_FAILED_COMMAND) {
+    if (tunnel->state == TS_CLOSING || tunnel->state == TS_FAILED_COMMAND) {
         const uint8_t* buf;
         unabto_stream_hint hint;
         size_t readen;
@@ -207,6 +207,7 @@ void unabto_tunnel_failed_command(tunnel* tunnel, tunnel_event_source tunnel_eve
     }
 }
 
+
 void unabto_tunnel_idle(tunnel* tunnel, tunnel_event_source event_source)
 {
     NABTO_LOG_ERROR(("Tunnel(%i), Event on tunnel which should not be in IDLE state. source %i, unabtoReadState %i, stream index %i, Tunnel type unrecognized.", tunnel->tunnelId, event_source,tunnel->unabtoReadState, unabto_stream_index(tunnel->stream)));
@@ -218,20 +219,29 @@ void unabto_tunnel_event_dispatch(tunnel* tunnel, tunnel_event_source tunnel_eve
 #if NABTO_ENABLE_TUNNEL_UART
     if (tunnel->tunnelType == TUNNEL_TYPE_UART) {
         unabto_tunnel_uart_event(tunnel, tunnel_event);
+        return;
     }
 #endif
 
 #if NABTO_ENABLE_TUNNEL_TCP
     if (tunnel->tunnelType == TUNNEL_TYPE_TCP) {
         unabto_tunnel_tcp_event(tunnel, tunnel_event);
+        return;
     }
 #endif
 
 #if NABTO_ENABLE_TUNNEL_ECHO
     if (tunnel->tunnelType == TUNNEL_TYPE_ECHO) {
         unabto_tunnel_echo_event(tunnel, tunnel_event);
+        return;
     }
 #endif
+
+    // else unknown type or closing.
+    if (tunnel->tunnelType == TUNNEL_TYPE_NONE) {
+        unabto_tunnel_closing(tunnel, tunnel_event);
+        return;
+    }
 }
 
 void unabto_tunnel_select_add_to_fd_set(fd_set* readFds, int* maxReadFd, fd_set* writeFds, int* maxWriteFd)

--- a/src/modules/tunnel/unabto_tunnel_common.h
+++ b/src/modules/tunnel/unabto_tunnel_common.h
@@ -46,6 +46,7 @@ typedef enum {
 } tunnel_event_source;
 
 typedef enum {
+    TUNNEL_TYPE_NONE,
     TUNNEL_TYPE_TCP,
     TUNNEL_TYPE_UART,
     TUNNEL_TYPE_ECHO
@@ -111,7 +112,7 @@ void unabto_tunnel_event(tunnel* tunnel, tunnel_event_source event_source);
 void unabto_tunnel_idle(tunnel* tunnel, tunnel_event_source tunnel_event);
 void unabto_tunnel_read_command(tunnel* tunnel, tunnel_event_source tunnel_event);
 void unabto_tunnel_parse_command(tunnel* tunnel, tunnel_event_source tunnel_event);
-void unabto_tunnel_failed_command(tunnel* tunnel, tunnel_event_source tunnel_event);
+void unabto_tunnel_closing(tunnel* tunnel, tunnel_event_source tunnel_event);
 
 void unabto_tunnel_event_dispatch(tunnel* tunnel, tunnel_event_source event_source);
 
@@ -123,6 +124,15 @@ bool tunnel_send_init_message(tunnel* tunnel, const char* msg);
 #if NABTO_ENABLE_EPOLL
 void unabto_tunnel_epoll_event(struct epoll_event* event);
 #endif
+
+/**
+ * Query at tunnel open request whether a client is allowed access (check ACL, optional functionality).
+ * @param connection  the connection being established
+ * @return            true if access to the devices is allowed
+ */
+bool unabto_tunnel_allow_client_access(nabto_connect* connection);
+
+
 
 
 #endif // _UNABTO_TUNNEL_COMMON_H_

--- a/src/unabto/unabto_app.h
+++ b/src/unabto/unabto_app.h
@@ -52,15 +52,6 @@ extern "C" {
 bool allow_client_access(nabto_connect* connection);
 #endif
 
-#if NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
-/**
- * Query at tunnel open request whether a client is allowed access (check ACL, optional functionality).
- * @param connection  the connection being established
- * @return            true if access to the devices is allowed
- */
-bool allow_client_tunnel(nabto_connect* connection);
-#endif
-
     
 /** Identifies the request including the caller */
 typedef struct {

--- a/src/unabto/unabto_app.h
+++ b/src/unabto/unabto_app.h
@@ -52,7 +52,16 @@ extern "C" {
 bool allow_client_access(nabto_connect* connection);
 #endif
 
+#if NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
+/**
+ * Query at tunnel open request whether a client is allowed access (check ACL, optional functionality).
+ * @param connection  the connection being established
+ * @return            true if access to the devices is allowed
+ */
+bool allow_client_tunnel(nabto_connect* connection);
+#endif
 
+    
 /** Identifies the request including the caller */
 typedef struct {
     uint32_t       queryId;    ///< The query id.

--- a/src/unabto/unabto_config_defaults.h
+++ b/src/unabto/unabto_config_defaults.h
@@ -109,11 +109,6 @@
 #define NABTO_ENABLE_CONNECTION_ESTABLISHMENT_ACL_CHECK 0
 #endif
 
-/** Query at tunnel open request whether a client is allowed access */
-#ifndef NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
-#define NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK 0
-#endif
-
 /**
  * Enable status callbacks. The status callback functionality enables
  * applications which uses the uNabto framework to get status callbacks

--- a/src/unabto/unabto_config_defaults.h
+++ b/src/unabto/unabto_config_defaults.h
@@ -109,6 +109,11 @@
 #define NABTO_ENABLE_CONNECTION_ESTABLISHMENT_ACL_CHECK 0
 #endif
 
+/** Query at tunnel open request whether a client is allowed access */
+#ifndef NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK
+#define NABTO_ENABLE_TUNNEL_OPEN_ACL_CHECK 0
+#endif
+
 /**
  * Enable status callbacks. The status callback functionality enables
  * applications which uses the uNabto framework to get status callbacks


### PR DESCRIPTION
tunnel and stream must be closed in a cleaner way in `unabto_tunnel_stream_accept` when rejecting a request, current approach with abruptly closing the stream messes up tunnel state - please add appropriate handling!