### PR TITLE
file_handling_improvement

### DIFF
--- a/src/modules/fingerprint_acl/fp_acl_file.c
+++ b/src/modules/fingerprint_acl/fp_acl_file.c
@@ -58,8 +58,8 @@ fp_acl_db_status fp_acl_file_load_file(struct fp_mem_state* acl)
         READ_U32(acl->users[i].permissions, buffer + FP_ACL_FP_LENGTH + FP_ACL_FILE_USERNAME_LENGTH);
     }
 
-	// close file, otherwise fp_acl_file_save_file() might throw error when updating the file
-	fclose(aclFile);
+    // close file, otherwise fp_acl_file_save_file() might throw error when updating the file
+    fclose(aclFile);
 
     return FP_ACL_DB_OK;
 }
@@ -118,9 +118,9 @@ fp_acl_db_status fp_acl_file_save_file(struct fp_mem_state* acl)
     fclose(aclFile);
 
     if (status == FP_ACL_DB_OK) {
-		
-		// remove destination file, otherwise rename() might throw an error 
-		remove(filename);
+        
+        // remove destination file, otherwise rename() might throw an error 
+        remove(filename);
         
         if (rename(tempFilename, filename) != 0) {
             return FP_ACL_DB_SAVE_FAILED;

--- a/src/modules/fingerprint_acl/fp_acl_file.c
+++ b/src/modules/fingerprint_acl/fp_acl_file.c
@@ -58,6 +58,9 @@ fp_acl_db_status fp_acl_file_load_file(struct fp_mem_state* acl)
         READ_U32(acl->users[i].permissions, buffer + FP_ACL_FP_LENGTH + FP_ACL_FILE_USERNAME_LENGTH);
     }
 
+	// close file, otherwise fp_acl_file_save_file() might throw error when updating the file
+	fclose(aclFile);
+
     return FP_ACL_DB_OK;
 }
 
@@ -115,6 +118,10 @@ fp_acl_db_status fp_acl_file_save_file(struct fp_mem_state* acl)
     fclose(aclFile);
 
     if (status == FP_ACL_DB_OK) {
+		
+		// remove destination file, otherwise rename() might throw an error 
+		remove(filename);
+        
         if (rename(tempFilename, filename) != 0) {
             return FP_ACL_DB_SAVE_FAILED;
         } 


### PR DESCRIPTION
When testing the appmyproduct-device-stub I had the problem, that I could not save data to the fingerprint-memory. The error was thrown from 'rename(tempFilename, filename)' because the destination file was still open.

OS: Windows 8.1, 64 Bit
Visual Studio 2015 Community
