### PR TITLE
Fix for NABTO-1844

### DIFF
--- a/src/unabto/unabto_packet.c
+++ b/src/unabto/unabto_packet.c
@@ -293,6 +293,8 @@ void handle_naf_packet(nabto_connect* con, nabto_packet_header* hdr, uint8_t* st
         con->relayIsActive = 1;
     }
 #endif
+
+    nabtoSetFutureStamp(&con->stamp, con->timeOut);
     
     nqs = framework_event_query(con, hdr, &handle);
     switch (nqs) {


### PR DESCRIPTION
fixing 4.2 regression: stamp not updated on incoming rpc requests causing connection to be closed if requests were made fast enough to prevent client from sending explicit keep-alive