### PR TITLE
Streaming fix

### DIFF
--- a/cmake/unabto_files.cmake
+++ b/cmake/unabto_files.cmake
@@ -485,5 +485,6 @@ set(unabto_server_common_src_test
 set(unabto_server_stream_test_src
   ${UNABTO_SERVER_SRC_DIR}/unabto/unabto_stream_event.c
   ${UNABTO_SERVER_TEST_DIR}/unabto/unabto_stream_event_test.c
+  ${UNABTO_SERVER_TEST_DIR}/unabto/unabto_stream_seq_exhaustion_test.c
   ${unabto_core_src}
 )

--- a/src/modules/timers/unix/unabto_unix_time.c
+++ b/src/modules/timers/unix/unabto_unix_time.c
@@ -64,7 +64,7 @@ struct unabto_unix_time unabto_unix_timer_get_stamp() {
 }
 
 // return s1 < s2
-bool unabto_unix_timer_stamp_less(nabto_stamp_t* s1, nabto_stamp_t* s2) {
+bool unabto_unix_timer_stamp_less(const nabto_stamp_t* s1, const nabto_stamp_t* s2) {
     if (s1->milliseconds < s2->milliseconds) {
         return true;
     }
@@ -74,7 +74,7 @@ bool unabto_unix_timer_stamp_less(nabto_stamp_t* s1, nabto_stamp_t* s2) {
     return false;
 }
 
-bool unabto_unix_timer_stamp_less_equal(nabto_stamp_t* s1, nabto_stamp_t* s2) {
+bool unabto_unix_timer_stamp_less_equal(const nabto_stamp_t* s1, const nabto_stamp_t* s2) {
     if (s1->milliseconds < s2->milliseconds) {
         return true;
     }

--- a/src/modules/timers/unix/unabto_unix_time.h
+++ b/src/modules/timers/unix/unabto_unix_time.h
@@ -14,8 +14,8 @@ extern "C" {
 
 nabto_stamp_t unabto_unix_timer_get_stamp();
 void unabto_unix_timer_add_stamp(nabto_stamp_t* stamp, int msec);
-bool unabto_unix_timer_stamp_less(nabto_stamp_t* s1, nabto_stamp_t* s2);
-bool unabto_unix_timer_stamp_less_equal(nabto_stamp_t* s1, nabto_stamp_t* s2);
+bool unabto_unix_timer_stamp_less(const nabto_stamp_t* s1, const nabto_stamp_t* s2);
+bool unabto_unix_timer_stamp_less_equal(const nabto_stamp_t* s1, const nabto_stamp_t* s2);
 
 /**
  * Switch auto update of the timestamp on/off

--- a/src/unabto/unabto_connection.h
+++ b/src/unabto/unabto_connection.h
@@ -170,6 +170,18 @@ struct nabto_connect_s {  // NOLINT(clang-analyzer-optin.performance.Padding)
     bool relayIsActive;  // data has been transmitted on relay, indicating client has chosen this type
 #endif
 
+    /* Per-connection stream-id counters. Monotonic for the lifetime
+     * of the connection slot — never wrapped, never reused. The
+     * value 0 is reserved as a sentinel meaning "no id assigned":
+     * the generators in unabto_stream_window.c skip 0 by starting
+     * these at 0 and incrementing before use, and the SYN handler
+     * sends idSP=0 in the RST it issues when allocation fails. Once
+     * a counter reaches 0xFFFF, further allocations on this
+     * connection fail (the peer can open a new connection to
+     * recover). Auto-zeroed by nabto_reset_connection. */
+    uint16_t nextIdCP;
+    uint16_t nextIdSP;
+
     /*****************************************************************************************/
     /* fields below has specific init, reinit and release methods.                           */
 

--- a/src/unabto/unabto_connection.h
+++ b/src/unabto/unabto_connection.h
@@ -173,7 +173,7 @@ struct nabto_connect_s {  // NOLINT(clang-analyzer-optin.performance.Padding)
     /* Per-connection stream-id counters. Monotonic for the lifetime
      * of the connection slot — never wrapped, never reused. The
      * value 0 is reserved as a sentinel meaning "no id assigned":
-     * the generators in unabto_stream_window.c skip 0 by starting
+     * the generator in unabto_stream_event.c skips 0 by starting
      * these at 0 and incrementing before use, and the SYN handler
      * sends idSP=0 in the RST it issues when allocation fails. Once
      * a counter reaches 0xFFFF, further allocations on this

--- a/src/unabto/unabto_next_event.c
+++ b/src/unabto/unabto_next_event.c
@@ -84,7 +84,7 @@ static void nabto_connection_update_next_event(nabto_stamp_t* current_min_stamp)
 #endif
 
 #if NABTO_ENABLE_NEXT_EVENT
-void nabto_update_min_stamp(nabto_stamp_t* current_minimum_stamp, nabto_stamp_t* stamp) {
+void nabto_update_min_stamp(nabto_stamp_t* current_minimum_stamp, const nabto_stamp_t* stamp) {
     if (nabtoStampLess(stamp, current_minimum_stamp)) {
         *current_minimum_stamp = *stamp;
     }

--- a/src/unabto/unabto_next_event.h
+++ b/src/unabto/unabto_next_event.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-void nabto_update_min_stamp(nabto_stamp_t* current_minimum_stamp, nabto_stamp_t* stamp);
+void nabto_update_min_stamp(nabto_stamp_t* current_minimum_stamp, const nabto_stamp_t* stamp);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/unabto/unabto_stream.c
+++ b/src/unabto/unabto_stream.c
@@ -53,10 +53,24 @@ bool unabto_stream_is_readable(unabto_stream* stream) {
     return nabto_stream_tcb_is_readable(stream);
 }
 
+/**
+ * If the stream was force-closed because of seq counter exhaustion,
+ * promote a generic close/error hint to UNABTO_STREAM_HINT_SEQ_EXHAUSTED
+ * so the application can distinguish this case and open a new stream.
+ */
+static void promote_seq_exhausted_hint(unabto_stream* stream, unabto_stream_hint* hint) {
+    if (stream->u.tcb.seqExhausted &&
+        (*hint == UNABTO_STREAM_HINT_STREAM_CLOSED ||
+         *hint == UNABTO_STREAM_HINT_READ_OR_WRITE_ERROR)) {
+        *hint = UNABTO_STREAM_HINT_SEQ_EXHAUSTED;
+    }
+}
+
 size_t unabto_stream_read(unabto_stream* stream, const uint8_t** buf, unabto_stream_hint* hint) {
     size_t avail = 0;
     stream->stats.userRead++;
     avail = nabto_stream_tcb_read(stream, buf, hint);
+    promote_seq_exhausted_hint(stream, hint);
     return avail;
 }
 
@@ -76,6 +90,7 @@ size_t unabto_stream_read_buf(unabto_stream* stream, uint8_t* buf, size_t size, 
     do {
         avail = nabto_stream_tcb_read(stream, &mem, hint);
         if (*hint != UNABTO_STREAM_HINT_OK) {
+            promote_seq_exhausted_hint(stream, hint);
             return 0;
         }
         if (avail > 0) {
@@ -113,12 +128,19 @@ size_t unabto_stream_write(unabto_stream* stream, const uint8_t* buf, size_t siz
     NABTO_LOG_TRACE(("write size=%" PRIsize, size));
     if (!nabto_stream_tcb_is_writeable(&stream->u.tcb)) {
         *hint = UNABTO_STREAM_HINT_READ_OR_WRITE_ERROR;
+        promote_seq_exhausted_hint(stream, hint);
         return 0;
     }
     queued = nabto_stream_tcb_write(stream, buf, size);
 
     NABTO_LOG_BUFFER(NABTO_LOG_SEVERITY_BUFFERS, ("Wrote on stream size %" PRIsize, queued), buf, queued);
-    *hint = UNABTO_STREAM_HINT_OK;
+    if (queued == 0 && stream->u.tcb.seqExhausted) {
+        /* Send-side guard tripped during this call: report exhaustion
+           rather than silent zero-write. */
+        *hint = UNABTO_STREAM_HINT_SEQ_EXHAUSTED;
+    } else {
+        *hint = UNABTO_STREAM_HINT_OK;
+    }
     return queued;
 }
 
@@ -127,6 +149,7 @@ size_t unabto_stream_can_write(unabto_stream* stream, unabto_stream_hint* hint) 
 
     if (!nabto_stream_tcb_is_writeable(&stream->u.tcb)) {
         *hint = UNABTO_STREAM_HINT_READ_OR_WRITE_ERROR;
+        promote_seq_exhausted_hint(stream, hint);
         return 0;
     }
     return nabto_stream_tcb_can_write(stream);

--- a/src/unabto/unabto_stream.c
+++ b/src/unabto/unabto_stream.c
@@ -134,9 +134,10 @@ size_t unabto_stream_write(unabto_stream* stream, const uint8_t* buf, size_t siz
     queued = nabto_stream_tcb_write(stream, buf, size);
 
     NABTO_LOG_BUFFER(NABTO_LOG_SEVERITY_BUFFERS, ("Wrote on stream size %" PRIsize, queued), buf, queued);
-    if (queued == 0 && stream->u.tcb.seqExhausted) {
-        /* Send-side guard tripped during this call: report exhaustion
-           rather than silent zero-write. */
+    if (stream->u.tcb.seqExhausted) {
+        /* Send-side guard tripped during this call (possibly after a
+           partial queue): report exhaustion so callers don't treat the
+           force-closed stream as still usable. */
         *hint = UNABTO_STREAM_HINT_SEQ_EXHAUSTED;
     } else {
         *hint = UNABTO_STREAM_HINT_OK;

--- a/src/unabto/unabto_stream.c
+++ b/src/unabto/unabto_stream.c
@@ -135,7 +135,7 @@ size_t unabto_stream_can_write(unabto_stream* stream, unabto_stream_hint* hint) 
 /******************************************************************************/
 
 bool unabto_stream_is_closed(unabto_stream* stream) {
-    return nabto_stream_tcb_is_closed(stream);
+    return nabto_stream_tcb_is_closed(&stream->u.tcb);
 }
 
 bool unabto_stream_close(unabto_stream* stream) {
@@ -148,7 +148,7 @@ bool unabto_stream_force_close(unabto_stream* stream) {
 }
 
 void unabto_stream_release(unabto_stream* stream) {
-    nabto_stream_tcb_release(stream);
+    nabto_stream_tcb_release(&stream->u.tcb);
     stream_reset(stream);
 }
 

--- a/src/unabto/unabto_stream.h
+++ b/src/unabto/unabto_stream.h
@@ -80,7 +80,14 @@ typedef enum {
     UNABTO_STREAM_HINT_READ_OR_WRITE_ERROR = 3,
     UNABTO_STREAM_HINT_ARGUMENT_ERROR = 4,
     UNABTO_STREAM_HINT_UNABLE_TO_ACKNOWLEDGE = 5,
-    UNABTO_STREAM_HINT_ACKNOWLEDGING_TOO_MUCH_DATA = 6
+    UNABTO_STREAM_HINT_ACKNOWLEDGING_TOO_MUCH_DATA = 6,
+    /**
+     * The 32-bit stream sequence counter has reached the safety threshold.
+     * The stream has been force-closed to prevent seq wrap-around, which
+     * could otherwise enable replay of previously-recorded packets under
+     * the still-valid connection key. Open a new stream to continue.
+     */
+    UNABTO_STREAM_HINT_SEQ_EXHAUSTED = 7
 } unabto_stream_hint;
 
 /**************** OPEN/CLOSE *******************************/

--- a/src/unabto/unabto_stream_event.c
+++ b/src/unabto/unabto_stream_event.c
@@ -377,7 +377,7 @@ void nabto_stream_update_next_event(nabto_stamp_t* current_min_stamp) {
             }
 
             // If we have unacked packets then check then use the best timeout we know of
-            nabto_stream_tcb_update_next_event(stream, current_min_stamp);
+            nabto_stream_tcb_update_next_event(&stream->u.tcb, current_min_stamp);
         }
     }
 }

--- a/src/unabto/unabto_stream_event.c
+++ b/src/unabto/unabto_stream_event.c
@@ -126,6 +126,7 @@ void nabto_stream_event(nabto_connect* con,
                 } else {
                     stream->idSP = idSP;
                     stream->idCP = win.idCP;
+                    stream->state = STREAM_IN_USE;
                 }
             }
         } else {

--- a/src/unabto/unabto_stream_event.c
+++ b/src/unabto/unabto_stream_event.c
@@ -273,6 +273,7 @@ void stream_init_static_config(struct nabto_stream_s* stream) {
     stream->staticConfig.defaultStreamTimeout = NABTO_STREAM_TIMEOUT;
     stream->staticConfig.minRetrans = NABTO_STREAM_MIN_RETRANS;
     stream->staticConfig.maxRetransmissionTime = NABTO_STREAM_MAX_RETRANSMISSION_TIME;
+    stream->staticConfig.seqExhaustionThreshold = NABTO_STREAM_SEQ_EXHAUSTION_THRESHOLD;
 }
 
 /**

--- a/src/unabto/unabto_stream_event.c
+++ b/src/unabto/unabto_stream_event.c
@@ -39,6 +39,15 @@ static struct nabto_stream_s* find_free_stream(uint16_t tag, nabto_connect* con)
 
 static bool nabto_stream_validate_win(struct nabto_win_info* info, struct nabto_stream_s* stream);
 
+static bool nabto_stream_next_sp_id(nabto_connect* con, uint16_t* idSP) {
+    if (con->nextIdSP == UINT16_MAX) {
+        return false;
+    }
+    ++con->nextIdSP;
+    *idSP = con->nextIdSP;
+    return true;
+}
+
 /******************************************************************************/
 
 void handle_stream_packet(nabto_connect* con, nabto_packet_header* hdr,
@@ -108,6 +117,16 @@ void nabto_stream_event(nabto_connect* con,
             stream = find_free_stream(hdr->tag, con);
             if (stream == NULL) {
                 NABTO_LOG_DEBUG(("Stream with tag %i not accepted", hdr->tag));
+            } else {
+                uint16_t idSP;
+                if (!nabto_stream_next_sp_id(con, &idSP)) {
+                    NABTO_LOG_ERROR(("Per-connection SPID space exhausted, sending RST"));
+                    unabto_stream_release(stream);
+                    stream = NULL;
+                } else {
+                    stream->idSP = idSP;
+                    stream->idCP = win.idCP;
+                }
             }
         } else {
             NABTO_LOG_DEBUG(("Received non syn packet for stream which is not available tag %i", hdr->tag));

--- a/src/unabto/unabto_stream_types.h
+++ b/src/unabto/unabto_stream_types.h
@@ -21,7 +21,7 @@ typedef struct nabto_stream_static_config {
     uint16_t defaultStreamTimeout;
     uint16_t minRetrans;
     uint16_t maxRetransmissionTime;
-
+    uint32_t seqExhaustionThreshold;
 } nabto_stream_static_config;
 
 /** Stream state */

--- a/src/unabto/unabto_stream_types.h
+++ b/src/unabto/unabto_stream_types.h
@@ -26,12 +26,16 @@ typedef struct nabto_stream_static_config {
 
 /** Stream state */
 struct nabto_stream_s {
-    uint16_t streamTag;                      /**< the tag                     */
-    struct nabto_connect_s* connection;      /**< the connection              */
+    struct nabto_connect_s* connection; /**< the connection              */
+    struct unabto_stream_stats_s stats; /**< Stats for the stream        */
+    union {
+        struct nabto_stream_tcb tcb; /**< state for unreliable con     */
+    } u;
     enum nabto_stream_state state;           /**< the state of the entry      */
+    nabto_stream_static_config staticConfig; /**< static configuration */
+    uint16_t streamTag;                      /**< the tag                     */
     uint16_t idCP;                           /**< ID, client part             */
     uint16_t idSP;                           /**< ID, serveer part            */
-    nabto_stream_static_config staticConfig; /**< static configuration */
     bool blockedOnMissingSendSegment;        /**< set to true if a stream send operation has been blocked by a missing segment allocation. */
     struct {
         bool dataReady : 1;
@@ -40,11 +44,6 @@ struct nabto_stream_s {
         bool writeClosed : 1;
         bool closed : 1;
     } applicationEvents;
-    struct unabto_stream_stats_s stats; /**< Stats for the stream        */
-
-    union {
-        struct nabto_stream_tcb tcb; /**< state for unreliable con     */
-    } u;
 };
 
 #ifdef __cplusplus

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -80,10 +80,8 @@ static void nabto_stream_state_transition(struct nabto_stream_s* stream, nabto_s
  */
 static bool congestion_control_accept_more_data(struct nabto_stream_tcb* tcb);
 
-static NABTO_THREAD_LOCAL_STORAGE uint16_t idSP__ = 0; /**< the one and only */
-static NABTO_THREAD_LOCAL_STORAGE uint16_t idCP__ = 0; /**< the one and only */
-static uint16_t nabto_stream_next_sp_id(void);
-static uint16_t nabto_stream_next_cp_id(void);
+static bool nabto_stream_next_sp_id(nabto_connect* con, uint16_t* idSP);
+static bool nabto_stream_next_cp_id(nabto_connect* con, uint16_t* idCP);
 
 static bool send_syn(struct nabto_stream_s* stream);
 static bool send_syn_ack(struct nabto_stream_s* stream);
@@ -102,7 +100,7 @@ void unabto_cwnd_flightsize_add(unabto_cwnd* cwnd, uint16_t flightSize);
 /**
  * Initialize state
  */
-static void nabto_init_stream_state(unabto_stream* stream, const struct nabto_win_info* info);
+static bool nabto_init_stream_state(unabto_stream* stream, const struct nabto_win_info* info);
 
 #if NABTO_LOG_CHECK(NABTO_LOG_SEVERITY_DEBUG)
 /**
@@ -302,12 +300,17 @@ text nabto_stream_tcb_state_name(const struct nabto_stream_tcb* tcb) {
     return stateNameW(tcb->streamState);
 }
 
-void nabto_stream_tcb_open(struct nabto_stream_s* stream) {
+bool nabto_stream_tcb_open(struct nabto_stream_s* stream) {
+    uint16_t idCP;
     nabto_init_stream_state_initiator(stream);
-    stream->idCP = nabto_stream_next_cp_id();
+    if (!nabto_stream_next_cp_id(stream->connection, &idCP)) {
+        return false;
+    }
+    stream->idCP = idCP;
     stream->state = STREAM_IN_USE;
     SET_STATE(stream, ST_SYN_SENT);
     nabtoSetFutureStamp(&stream->u.tcb.timeoutStamp, 0);
+    return true;
 }
 
 /******************************************************************************/
@@ -1218,7 +1221,15 @@ void nabto_stream_tcb_event(struct nabto_stream_s* stream,
     switch (tcb->streamState) {
         case ST_IDLE:
             if (win->type == SYN) {
-                nabto_init_stream_state(stream, win);  // calls nabto_init_stream_tcb_state
+                if (!nabto_init_stream_state(stream, win)) {
+                    // Per-connection stream id space exhausted; reply
+                    // RST with idSP=0 sentinel so the initiator can
+                    // tear down immediately instead of timing out.
+                    NABTO_LOG_ERROR(("stream id space exhausted on connection, sending RST"));
+                    send_rst(stream);
+                    unabto_stream_release(stream);
+                    return;
+                }
                 if (!unabto_stream_init_buffers(stream)) {
                     // release the stream as we cannot allocate buffers for the stream.
                     send_rst(stream);
@@ -1977,27 +1988,39 @@ void unabto_stream_dump_state(struct nabto_stream_s* stream) {
  * @param stream  the stream
  * @param info    the request
  */
-static void nabto_init_stream_state(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
-    stream->state = STREAM_IN_USE;
-    stream->idCP = info->idCP;
-    stream->idSP = nabto_stream_next_sp_id();
-    nabto_init_stream_tcb_state(&stream->u.tcb, info, stream);
-}
-
-static uint16_t nabto_stream_next_sp_id(void) {
+static bool nabto_init_stream_state(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
     uint16_t idSP;
-    do {
-        idSP = ++idSP__;
-    } while (idSP == 0);
-    return idSP;
+    if (!nabto_stream_next_sp_id(stream->connection, &idSP)) {
+        // Id space exhausted on this connection. Set idSP=0 (reserved
+        // sentinel) and copy idCP so the SYN handler can send a
+        // meaningful RST.
+        stream->idSP = 0;
+        stream->idCP = info->idCP;
+        return false;
+    }
+    stream->idSP = idSP;
+    stream->idCP = info->idCP;
+    stream->state = STREAM_IN_USE;
+    nabto_init_stream_tcb_state(&stream->u.tcb, info, stream);
+    return true;
 }
 
-static uint16_t nabto_stream_next_cp_id(void) {
-    uint16_t idCP;
-    do {
-        idCP = ++idCP__;
-    } while (idCP == 0);
-    return idCP;
+static bool nabto_stream_next_sp_id(nabto_connect* con, uint16_t* idSP) {
+    if (con->nextIdSP == UINT16_MAX) {
+        return false;
+    }
+    ++con->nextIdSP;
+    *idSP = con->nextIdSP;
+    return true;
+}
+
+static bool nabto_stream_next_cp_id(nabto_connect* con, uint16_t* idCP) {
+    if (con->nextIdCP == UINT16_MAX) {
+        return false;
+    }
+    ++con->nextIdCP;
+    *idCP = con->nextIdCP;
+    return true;
 }
 
 void unabto_stat_time_init(struct unabto_stats_time* stat) {

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -94,11 +94,6 @@ void unabto_cwnd_add(unabto_cwnd* cwnd, uint16_t value);
 void unabto_cwnd_sub_one(unabto_cwnd* cwnd);
 void unabto_cwnd_flightsize_add(unabto_cwnd* cwnd, uint16_t flightSize);
 
-/**
- * Initialize state
- */
-static bool nabto_init_stream_state(unabto_stream* stream, const struct nabto_win_info* info);
-
 #if NABTO_LOG_CHECK(NABTO_LOG_SEVERITY_DEBUG)
 /**
  * convert a window type to a const string
@@ -1215,15 +1210,7 @@ void nabto_stream_tcb_event(struct nabto_stream_s* stream,
     switch (tcb->streamState) {
         case ST_IDLE:
             if (win->type == SYN) {
-                if (!nabto_init_stream_state(stream, win)) {
-                    // Per-connection stream id space exhausted; reply
-                    // RST with idSP=0 sentinel so the initiator can
-                    // tear down immediately instead of timing out.
-                    NABTO_LOG_ERROR(("stream id space exhausted on connection, sending RST"));
-                    send_rst(stream);
-                    unabto_stream_release(stream);
-                    return;
-                }
+                nabto_init_stream_tcb_state(&stream->u.tcb, win, stream);
                 if (!unabto_stream_init_buffers(stream)) {
                     // release the stream as we cannot allocate buffers for the stream.
                     send_rst(stream);
@@ -1975,25 +1962,6 @@ void unabto_stream_dump_state(struct nabto_stream_s* stream) {
     NABTO_LOG_TRACE(("  ssThreshold %" PRIu16, tcb->cCtrl.ssThreshold));
     NABTO_LOG_TRACE(("  flightSize %" PRIu16, tcb->cCtrl.flightSize));
 #endif
-}
-
-/**
- * Initialise the stream configuration from received request.
- * @param stream  the stream
- * @param info    the request
- */
-static bool nabto_init_stream_state(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
-    // Precondition: caller has assigned stream->idSP from its per-connection
-    // allocator (e.g. nabto_stream_event in the firmware build) before
-    // dispatching the SYN here.
-    if (stream->idSP == 0) {
-        stream->idCP = info->idCP;
-        return false;
-    }
-    stream->idCP = info->idCP;
-    stream->state = STREAM_IN_USE;
-    nabto_init_stream_tcb_state(&stream->u.tcb, info, stream);
-    return true;
 }
 
 void unabto_stat_time_init(struct unabto_stats_time* stat) {

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -227,7 +227,7 @@ void nabto_init_stream_tcb_state(struct nabto_stream_tcb* tcb, const struct nabt
 void nabto_limit_stream_config_syn_ack(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
     struct nabto_stream_tcb* tcb = &stream->u.tcb;
     nabto_limit_stream_config(&stream->u.tcb, &info->u.syn.cfg);
-    
+
     // This is a bug it should have been info->seq+1
     stream->u.tcb.recvNext = info->seq;
     stream->u.tcb.recvTop = stream->u.tcb.recvNext;

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -297,18 +297,14 @@ text nabto_stream_tcb_state_name(const struct nabto_stream_tcb* tcb) {
     return stateNameW(tcb->streamState);
 }
 
-bool nabto_stream_tcb_open(struct nabto_stream_s* stream) {
-    // Precondition: caller has assigned stream->idCP from its per-session
-    // allocator (e.g. FramingStreamManagerC::nextCpid in the C++ build, or
-    // an allocation site in the firmware that calls into this function).
-    if (stream->idCP == 0) {
-        return false;
-    }
+void nabto_stream_tcb_open(struct nabto_stream_s* stream, uint16_t idCP) {
+    // Precondition: idCP is non-zero. Allocation is the caller's job
+    // (e.g. FramingStreamManagerC::nextCpid in the C++ build).
+    stream->idCP = idCP;
     nabto_init_stream_state_initiator(stream);
     stream->state = STREAM_IN_USE;
     SET_STATE(stream, ST_SYN_SENT);
     nabtoSetFutureStamp(&stream->u.tcb.timeoutStamp, 0);
-    return true;
 }
 
 /******************************************************************************/

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -224,7 +224,7 @@ void nabto_init_stream_tcb_state(struct nabto_stream_tcb* tcb, const struct nabt
 void nabto_limit_stream_config_syn_ack(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
     struct nabto_stream_tcb* tcb = &stream->u.tcb;
     nabto_limit_stream_config(&stream->u.tcb, &info->u.syn.cfg);
-    stream->idSP = info->idSP;
+    
     // This is a bug it should have been info->seq+1
     stream->u.tcb.recvNext = info->seq;
     stream->u.tcb.recvTop = stream->u.tcb.recvNext;
@@ -308,7 +308,7 @@ void nabto_stream_tcb_open(struct nabto_stream_s* stream, uint16_t idCP) {
 size_t nabto_stream_tcb_read(struct nabto_stream_s* stream, const uint8_t** buf, unabto_stream_hint* hint) {
     // recv while recvNext < recvTop
 
-    if (nabto_stream_tcb_is_closed(stream)) {
+    if (nabto_stream_tcb_is_closed(&stream->u.tcb)) {
         *hint = UNABTO_STREAM_HINT_STREAM_CLOSED;
         return 0;
     }
@@ -465,7 +465,7 @@ static bool send_data_packet(struct nabto_stream_s* stream, uint32_t seq, uint8_
     NABTO_NOT_USED(ackNumber);
     NABTO_NOT_USED(tcb);
 
-    unabto_stream_create_sack_pairs(stream, &sackData);
+    unabto_stream_create_sack_pairs(tcb, &sackData);
 
     if (build_and_send_packet(stream, ACK, seq, 0, 0, data, size, &sackData)) {
         if (size) {
@@ -1417,8 +1417,7 @@ bool nabto_stream_tcb_handle_fin(struct nabto_stream_tcb* tcb, struct nabto_win_
  *
  * @return true iff there are any sack pairs available.
  */
-bool unabto_stream_create_sack_pairs(struct nabto_stream_s* stream, struct nabto_stream_sack_data* sackData) {
-    struct nabto_stream_tcb* tcb = &stream->u.tcb;
+bool unabto_stream_create_sack_pairs(struct nabto_stream_tcb* tcb, struct nabto_stream_sack_data* sackData) {
     uint32_t end = 0;
     uint32_t i;
 
@@ -1517,7 +1516,7 @@ bool nabto_stream_tcb_close(struct nabto_stream_s* stream) {
         }
     }
 
-    return nabto_stream_tcb_is_closed(stream);
+    return nabto_stream_tcb_is_closed(&stream->u.tcb);
 }
 
 bool nabto_stream_tcb_force_close(struct nabto_stream_s* stream) {
@@ -1557,16 +1556,14 @@ void nabto_stream_tcb_on_connection_released(struct nabto_stream_s* stream) {
     }
 }
 
-void nabto_stream_tcb_release(struct nabto_stream_s* stream) {
+void nabto_stream_tcb_release(struct nabto_stream_tcb* tcb) {
     size_t i;
-    struct nabto_stream_tcb* tcb;
-    if (!nabto_stream_tcb_is_closed(stream)) {
-        NABTO_LOG_TRACE(("Releasing stream in state %d - %" PRItext, stream->u.tcb.streamState, nabto_stream_tcb_state_name(&stream->u.tcb)));
+    if (!nabto_stream_tcb_is_closed(tcb)) {
+        NABTO_LOG_TRACE(("Releasing stream in state %d - %" PRItext, tcb->streamState, nabto_stream_tcb_state_name(tcb)));
     }
     // run through the stream send window and free all unfreed send
     // segments.  there can be unfreed segments if the stream is
     // closed without all the data being acked.
-    tcb = &stream->u.tcb;
     if (tcb->xmit != NULL) {
         for (i = 0; i < tcb->cfg.xmitWinSize; i++) {
             if (tcb->xmit[i].xstate != B_IDLE) {
@@ -1586,13 +1583,12 @@ void nabto_stream_tcb_release(struct nabto_stream_s* stream) {
     }
 }
 
-bool nabto_stream_tcb_is_closed(struct nabto_stream_s* stream) {
-    return stream->u.tcb.streamState == ST_CLOSED || stream->u.tcb.streamState == ST_CLOSED_ABORTED;
+bool nabto_stream_tcb_is_closed(const struct nabto_stream_tcb* tcb) {
+    return tcb->streamState == ST_CLOSED || tcb->streamState == ST_CLOSED_ABORTED;
 }
 
 #if NABTO_ENABLE_NEXT_EVENT
-void nabto_stream_tcb_update_next_event(struct nabto_stream_s* stream, nabto_stamp_t* current_min_stamp) {
-    struct nabto_stream_tcb* tcb = &stream->u.tcb;
+void nabto_stream_tcb_update_next_event(const struct nabto_stream_tcb* tcb, nabto_stamp_t* current_min_stamp) {
     if (tcb->streamState == ST_CLOSED || tcb->streamState == ST_CLOSED_ABORTED) {
         return;
     }

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -214,6 +214,9 @@ void nabto_init_stream_tcb_state(struct nabto_stream_tcb* tcb, const struct nabt
     tcb->recvMax = tcb->recvNext;
     tcb->retransCount = 0;
     tcb->maxAdvertisedWindow = info->ack + stream->u.tcb.cfg.xmitWinSize;
+    tcb->xmitDataCount = 0;
+    tcb->recvDataCount = 0;
+    tcb->seqExhausted = false;
 
     unabto_stream_congestion_control_init(tcb);
 }
@@ -379,8 +382,16 @@ size_t nabto_stream_tcb_write(struct nabto_stream_s* stream, const uint8_t* buf,
                (tcb->xmitSeq < tcb->maxAdvertisedWindow) &&
                congestion_control_accept_more_data(tcb)) {
             uint16_t sz;
-            int ix = (int)(tcb->xmitSeq % tcb->cfg.xmitWinSize);
-            x_buffer* xbuf = &tcb->xmit[ix];
+            int ix;
+            x_buffer* xbuf;
+            if (tcb->xmitDataCount >= stream->staticConfig.seqExhaustionThreshold) {
+                NABTO_LOG_WARN(("%" PRIu16 " send seq counter exhausted after %" PRIu32 " packets, force-closing to prevent wrap-around", stream->streamTag, tcb->xmitDataCount));
+                tcb->seqExhausted = true;
+                nabto_stream_tcb_force_close(stream);
+                break;
+            }
+            ix = (int)(tcb->xmitSeq % tcb->cfg.xmitWinSize);
+            xbuf = &tcb->xmit[ix];
             if (xbuf->xstate != B_IDLE) {
                 NABTO_LOG_FATAL(("xbuf->xstate != B_IDLE, xmitCount=%u finSent=%u", (int)tcb->xmitLastSent - tcb->xmitFirst, tcb->finSequence));
             }
@@ -403,6 +414,7 @@ size_t nabto_stream_tcb_write(struct nabto_stream_s* stream, const uint8_t* buf,
             queued += sz;
             size -= sz;
             ++tcb->xmitSeq;  // done here or after sending?
+            ++tcb->xmitDataCount;
 
             if ((tcb->xmitSeq - tcb->xmitFirst) == 1) {
                 // restart retransmission timer
@@ -1124,6 +1136,7 @@ static void handle_data(struct nabto_stream_s* stream,
                     rbuf->size = dlen;
                     rbuf->used = 0;
                     rbuf->seq = win->seq;
+                    ++tcb->recvDataCount;
                     LOG_STATE(stream);
                     // update the highest received data sequence number, used in sack calculation.
                     tcb->recvMax = MAX(tcb->recvMax, win->seq);
@@ -1179,6 +1192,23 @@ void nabto_stream_tcb_event(struct nabto_stream_s* stream,
     struct nabto_stream_tcb* tcb = &stream->u.tcb;
 
     NABTO_LOG_DEBUG(("%" PRIu16 " --> [%" PRIu32 ",%" PRIu32 "] %" PRItext ", advertisedWindow %" PRIu16 ", %d bytes", stream->streamTag, win->seq, win->ack, unabto_stream_type_to_string(win->type), win->advertisedWindow, dlen));
+
+    /**
+     * Refuse to advance the receive window past the seq exhaustion
+     * threshold. Without this, recvNext could wrap to zero and accept old
+     * recorded packets (whose HMAC remains valid under the unchanged
+     * connection key) inside the wrapped window. RST is allowed through
+     * so a peer's exhaustion-driven RST can still tear us down cleanly.
+     */
+    if (!(win->type & RST) &&
+        tcb->recvDataCount >= stream->staticConfig.seqExhaustionThreshold) {
+        if (tcb->streamState != ST_CLOSED && tcb->streamState != ST_CLOSED_ABORTED) {
+            NABTO_LOG_WARN(("%" PRIu16 " recv seq counter exhausted after %" PRIu32 " packets, force-closing to prevent wrap-around", stream->streamTag, tcb->recvDataCount));
+            tcb->seqExhausted = true;
+            nabto_stream_tcb_force_close(stream);
+        }
+        return;
+    }
 
     if (win->type == ACK) {
         uint32_t oldAdvWindow = tcb->maxAdvertisedWindow;

--- a/src/unabto/unabto_stream_window.c
+++ b/src/unabto/unabto_stream_window.c
@@ -80,9 +80,6 @@ static void nabto_stream_state_transition(struct nabto_stream_s* stream, nabto_s
  */
 static bool congestion_control_accept_more_data(struct nabto_stream_tcb* tcb);
 
-static bool nabto_stream_next_sp_id(nabto_connect* con, uint16_t* idSP);
-static bool nabto_stream_next_cp_id(nabto_connect* con, uint16_t* idCP);
-
 static bool send_syn(struct nabto_stream_s* stream);
 static bool send_syn_ack(struct nabto_stream_s* stream);
 static bool send_syn_or_syn_ack(struct nabto_stream_s* stream, uint8_t type);
@@ -301,12 +298,13 @@ text nabto_stream_tcb_state_name(const struct nabto_stream_tcb* tcb) {
 }
 
 bool nabto_stream_tcb_open(struct nabto_stream_s* stream) {
-    uint16_t idCP;
-    nabto_init_stream_state_initiator(stream);
-    if (!nabto_stream_next_cp_id(stream->connection, &idCP)) {
+    // Precondition: caller has assigned stream->idCP from its per-session
+    // allocator (e.g. FramingStreamManagerC::nextCpid in the C++ build, or
+    // an allocation site in the firmware that calls into this function).
+    if (stream->idCP == 0) {
         return false;
     }
-    stream->idCP = idCP;
+    nabto_init_stream_state_initiator(stream);
     stream->state = STREAM_IN_USE;
     SET_STATE(stream, ST_SYN_SENT);
     nabtoSetFutureStamp(&stream->u.tcb.timeoutStamp, 0);
@@ -1989,37 +1987,16 @@ void unabto_stream_dump_state(struct nabto_stream_s* stream) {
  * @param info    the request
  */
 static bool nabto_init_stream_state(struct nabto_stream_s* stream, const struct nabto_win_info* info) {
-    uint16_t idSP;
-    if (!nabto_stream_next_sp_id(stream->connection, &idSP)) {
-        // Id space exhausted on this connection. Set idSP=0 (reserved
-        // sentinel) and copy idCP so the SYN handler can send a
-        // meaningful RST.
-        stream->idSP = 0;
+    // Precondition: caller has assigned stream->idSP from its per-connection
+    // allocator (e.g. nabto_stream_event in the firmware build) before
+    // dispatching the SYN here.
+    if (stream->idSP == 0) {
         stream->idCP = info->idCP;
         return false;
     }
-    stream->idSP = idSP;
     stream->idCP = info->idCP;
     stream->state = STREAM_IN_USE;
     nabto_init_stream_tcb_state(&stream->u.tcb, info, stream);
-    return true;
-}
-
-static bool nabto_stream_next_sp_id(nabto_connect* con, uint16_t* idSP) {
-    if (con->nextIdSP == UINT16_MAX) {
-        return false;
-    }
-    ++con->nextIdSP;
-    *idSP = con->nextIdSP;
-    return true;
-}
-
-static bool nabto_stream_next_cp_id(nabto_connect* con, uint16_t* idCP) {
-    if (con->nextIdCP == UINT16_MAX) {
-        return false;
-    }
-    ++con->nextIdCP;
-    *idCP = con->nextIdCP;
     return true;
 }
 

--- a/src/unabto/unabto_stream_window.h
+++ b/src/unabto/unabto_stream_window.h
@@ -247,7 +247,7 @@ extern "C" {
  * Precondition: The stream structure has been initialized and
  * prepared for opening by giving it a tag and a connection.
  */
-void nabto_stream_tcb_open(struct nabto_stream_s* stream);
+bool nabto_stream_tcb_open(struct nabto_stream_s* stream);
 
 /**
  * Read data

--- a/src/unabto/unabto_stream_window.h
+++ b/src/unabto/unabto_stream_window.h
@@ -332,15 +332,15 @@ text nabto_stream_tcb_state_name(const struct nabto_stream_tcb* tcb);
  */
 void nabto_init_stream_tcb_state(struct nabto_stream_tcb* tcb, const struct nabto_win_info* info, struct nabto_stream_s* stream);
 
-void nabto_stream_tcb_release(struct nabto_stream_s* stream);
+void nabto_stream_tcb_release(struct nabto_stream_tcb* tcb);
 
-bool nabto_stream_tcb_is_closed(struct nabto_stream_s* stream);
+bool nabto_stream_tcb_is_closed(const struct nabto_stream_tcb* tcb);
 
 #if NABTO_ENABLE_NEXT_EVENT
 /**
  * Update time stamp with the time until next event
  */
-void nabto_stream_tcb_update_next_event(struct nabto_stream_s* stream, nabto_stamp_t* current_min_stamp);
+void nabto_stream_tcb_update_next_event(const struct nabto_stream_tcb* tcb, nabto_stamp_t* current_min_stamp);
 #endif
 
 void nabto_stream_make_rst_response_window(const struct nabto_win_info* win, struct nabto_win_info* rstWin);
@@ -352,7 +352,7 @@ bool nabto_stream_encode_window(const struct nabto_win_info* win, uint8_t* start
 uint16_t unabto_stream_advertised_window_size(struct nabto_stream_tcb* tcb);
 uint32_t unabto_stream_ack_number_to_send(struct nabto_stream_tcb* tcb);
 
-bool unabto_stream_create_sack_pairs(struct nabto_stream_s* stream, struct nabto_stream_sack_data* sackData);
+bool unabto_stream_create_sack_pairs(struct nabto_stream_tcb* tcb, struct nabto_stream_sack_data* sackData);
 /******************************************************************************/
 /******************************************************************************/
 

--- a/src/unabto/unabto_stream_window.h
+++ b/src/unabto/unabto_stream_window.h
@@ -242,12 +242,13 @@ extern "C" {
 #endif
 
 /**
- * open a stream
+ * Open a stream as the initiator. The caller supplies the per-session
+ * client-peer stream id (idCP); allocation is the caller's responsibility.
  *
- * Precondition: The stream structure has been initialized and
- * prepared for opening by giving it a tag and a connection.
+ * Precondition: the stream structure has been initialized and given a tag,
+ * and idCP is non-zero (0 is the reserved "no id assigned" sentinel).
  */
-bool nabto_stream_tcb_open(struct nabto_stream_s* stream);
+void nabto_stream_tcb_open(struct nabto_stream_s* stream, uint16_t idCP);
 
 /**
  * Read data

--- a/src/unabto/unabto_stream_window.h
+++ b/src/unabto/unabto_stream_window.h
@@ -22,6 +22,19 @@
 #include <unabto/unabto_protocol_defines.h>
 #include <unabto/unabto_stream.h>
 
+/**
+ * Maximum number of sequence numbers a single stream may consume on either
+ * direction before being force-closed. Each side maintains its own zero-based
+ * counter (independent of the actual starting seq), and the stream is
+ * force-closed when its counter reaches this threshold. This caps the seq
+ * advancement on a stream. If the stream sequence number is reused, the stream is
+ * susceptible to a replay attack where a packet from earlier could be replayed
+ * once the 32bit counter reaches the same value again.
+ */
+#ifndef NABTO_STREAM_SEQ_EXHAUSTION_THRESHOLD
+#define NABTO_STREAM_SEQ_EXHAUSTION_THRESHOLD 0x80000000u
+#endif
+
 /** Stream Transfer Control Block Configuration */
 typedef struct nabto_stream_tcb_config {
     uint16_t recvPacketSize;  ///< receiver packet size
@@ -167,6 +180,24 @@ struct nabto_stream_tcb {
     nabto_stamp_t dataTimeoutStamp; /**< Timeout stamp for data  */
     nabto_stamp_t ackStamp;         /**< time to send unsolicited ACK         */
     uint32_t maxAdvertisedWindow;
+
+    /**
+     * Per-direction zero-based counters used to detect seq exhaustion
+     * independently of the actual initial seq. xmitDataCount increments
+     * each time outgoing data consumes a seq; recvDataCount increments
+     * each time a previously-unseen seq is accepted into the receive
+     * window. Reaching NABTO_STREAM_SEQ_EXHAUSTION_THRESHOLD force-closes
+     * the stream.
+     */
+    uint32_t xmitDataCount;
+    uint32_t recvDataCount;
+
+    /**
+     * True iff this stream was force-closed because either direction's
+     * counter reached the exhaustion threshold. Used to surface
+     * UNABTO_STREAM_HINT_SEQ_EXHAUSTED to the application.
+     */
+    bool seqExhausted;
 
     uint32_t finSequence; /**< The sequence number of the fin. */
 

--- a/test/unabto/unabto_stream_event_test.c
+++ b/test/unabto/unabto_stream_event_test.c
@@ -50,6 +50,10 @@ void resetStream(struct nabto_stream_s* stream) {
     memset(r_buffers2, 0, sizeof(r_buffers2));
     memset(&test_connection, 0, sizeof(test_connection));
     stream->connection = &test_connection;
+    // SPID is now allocated by nabto_stream_event before reaching the
+    // TCB state machine; simulate that here so the SYN handler sees a
+    // non-zero idSP.
+    stream->idSP = 1;
     nmc.nabtoMainSetup.id = "";
     stream_initial_config(stream);
     stream_init_static_config(stream);

--- a/test/unabto/unabto_stream_event_test.c
+++ b/test/unabto/unabto_stream_event_test.c
@@ -1,4 +1,6 @@
 #include <unabto/unabto_env_base.h>
+#include <unabto/unabto_connection.h>
+#include <unabto/unabto_memory.h>
 #include <unabto/unabto_stream_event.h>
 #include <unabto/unabto_stream_window.h>
 #include <unabto/unabto_stream_environment.h>
@@ -40,11 +42,15 @@ void make_ack_window(struct nabto_win_info* window, uint32_t ack, uint32_t seq) 
 
 x_buffer x_buffers2[NABTO_STREAM_SEND_WINDOW_SIZE];
 r_buffer r_buffers2[NABTO_STREAM_RECEIVE_WINDOW_SIZE];
+static struct nabto_connect_s test_connection;
 
 void resetStream(struct nabto_stream_s* stream) {
     memset(stream, 0, sizeof(struct nabto_stream_s));
     memset(x_buffers2, 0, sizeof(x_buffers2));
     memset(r_buffers2, 0, sizeof(r_buffers2));
+    memset(&test_connection, 0, sizeof(test_connection));
+    stream->connection = &test_connection;
+    nmc.nabtoMainSetup.id = "";
     stream_initial_config(stream);
     stream_init_static_config(stream);
     stream->u.tcb.cfg.xmitWinSize = NABTO_STREAM_SEND_WINDOW_SIZE;

--- a/test/unabto/unabto_stream_event_test.c
+++ b/test/unabto/unabto_stream_event_test.c
@@ -50,10 +50,6 @@ void resetStream(struct nabto_stream_s* stream) {
     memset(r_buffers2, 0, sizeof(r_buffers2));
     memset(&test_connection, 0, sizeof(test_connection));
     stream->connection = &test_connection;
-    // SPID is now allocated by nabto_stream_event before reaching the
-    // TCB state machine; simulate that here so the SYN handler sees a
-    // non-zero idSP.
-    stream->idSP = 1;
     nmc.nabtoMainSetup.id = "";
     stream_initial_config(stream);
     stream_init_static_config(stream);

--- a/test/unabto/unabto_stream_seq_exhaustion_test.c
+++ b/test/unabto/unabto_stream_seq_exhaustion_test.c
@@ -1,0 +1,122 @@
+#include <unabto/unabto_env_base.h>
+#include <unabto/unabto_connection.h>
+#include <unabto/unabto_main_contexts.h>
+#include <unabto/unabto_memory.h>
+#include <unabto/unabto_stream.h>
+#include <unabto/unabto_stream_event.h>
+#include <unabto/unabto_stream_environment.h>
+#include <unabto/unabto_stream_types.h>
+#include <unabto/unabto_stream_window.h>
+
+#include "unabto_stream_seq_exhaustion_test.h"
+
+#include <string.h>
+
+// unabto_stream_accept / unabto_stream_event dummies are defined in
+// unabto_stream_event_test.c and resolved at link time.
+
+enum {
+    SEQ_TEST_ACK = NP_PAYLOAD_WINDOW_FLAG_ACK
+};
+
+static x_buffer seq_test_x[NABTO_STREAM_SEND_WINDOW_SIZE];
+static r_buffer seq_test_r[NABTO_STREAM_RECEIVE_WINDOW_SIZE];
+static struct nabto_connect_s seq_test_connection;
+
+static void reset_seq_stream(struct nabto_stream_s* stream) {
+    memset(stream, 0, sizeof(struct nabto_stream_s));
+    memset(seq_test_x, 0, sizeof(seq_test_x));
+    memset(seq_test_r, 0, sizeof(seq_test_r));
+    memset(&seq_test_connection, 0, sizeof(seq_test_connection));
+    stream->connection = &seq_test_connection;
+    nmc.nabtoMainSetup.id = "";
+    stream_initial_config(stream);
+    stream_init_static_config(stream);
+    stream->u.tcb.cfg = stream->u.tcb.initialConfig;
+    stream->u.tcb.xmit = seq_test_x;
+    stream->u.tcb.recv = seq_test_r;
+    unabto_stream_congestion_control_init(&stream->u.tcb);
+}
+
+static bool test_send_seq_exhaustion(void) {
+    struct nabto_stream_s* stream = &stream__[0];
+    reset_seq_stream(stream);
+
+    struct nabto_stream_tcb* tcb = &stream->u.tcb;
+    tcb->streamState = ST_ESTABLISHED;
+    tcb->xmitFirst = 0;
+    tcb->xmitLastSent = 0;
+    tcb->xmitSeq = 0;
+    tcb->maxAdvertisedWindow = tcb->cfg.xmitWinSize;
+
+    stream->staticConfig.seqExhaustionThreshold = 4;
+    tcb->xmitDataCount = stream->staticConfig.seqExhaustionThreshold;
+
+    uint8_t buf[8];
+    memset(buf, 0xab, sizeof(buf));
+    size_t queued = nabto_stream_tcb_write(stream, buf, sizeof(buf));
+
+    if (queued != 0) {
+        NABTO_LOG_ERROR(("seq exhaustion send: expected queued=0 after threshold, got %u", (unsigned)queued));
+        return false;
+    }
+    if (!tcb->seqExhausted) {
+        NABTO_LOG_ERROR(("seq exhaustion send: seqExhausted flag not set"));
+        return false;
+    }
+    if (tcb->streamState != ST_CLOSED_ABORTED) {
+        NABTO_LOG_ERROR(("seq exhaustion send: stream not force-closed (state=%d)", (int)tcb->streamState));
+        return false;
+    }
+
+    unabto_stream_hint hint = UNABTO_STREAM_HINT_OK;
+    size_t w = unabto_stream_write(stream, buf, sizeof(buf), &hint);
+    if (w != 0) {
+        NABTO_LOG_ERROR(("seq exhaustion send: unabto_stream_write returned %u, expected 0", (unsigned)w));
+        return false;
+    }
+    if (hint != UNABTO_STREAM_HINT_SEQ_EXHAUSTED) {
+        NABTO_LOG_ERROR(("seq exhaustion send: unabto_stream_write hint=%d, expected UNABTO_STREAM_HINT_SEQ_EXHAUSTED", (int)hint));
+        return false;
+    }
+    return true;
+}
+
+static bool test_recv_seq_exhaustion(void) {
+    struct nabto_stream_s* stream = &stream__[0];
+    reset_seq_stream(stream);
+
+    struct nabto_stream_tcb* tcb = &stream->u.tcb;
+    tcb->streamState = ST_ESTABLISHED;
+
+    stream->staticConfig.seqExhaustionThreshold = 4;
+    tcb->recvDataCount = stream->staticConfig.seqExhaustionThreshold;
+
+    struct nabto_win_info win;
+    memset(&win, 0, sizeof(win));
+    win.type = SEQ_TEST_ACK;
+    win.ack = tcb->xmitSeq;
+    win.seq = tcb->recvNext;
+
+    struct nabto_stream_sack_data sack;
+    memset(&sack, 0, sizeof(sack));
+
+    nabto_stream_tcb_event(stream, &win, NULL, 0, &sack);
+
+    if (!tcb->seqExhausted) {
+        NABTO_LOG_ERROR(("seq exhaustion recv: seqExhausted flag not set"));
+        return false;
+    }
+    if (tcb->streamState != ST_CLOSED_ABORTED) {
+        NABTO_LOG_ERROR(("seq exhaustion recv: stream not force-closed (state=%d)", (int)tcb->streamState));
+        return false;
+    }
+    return true;
+}
+
+bool unabto_stream_seq_exhaustion_test(void) {
+    bool ret = true;
+    ret &= test_send_seq_exhaustion();
+    ret &= test_recv_seq_exhaustion();
+    return ret;
+}

--- a/test/unabto/unabto_stream_seq_exhaustion_test.h
+++ b/test/unabto/unabto_stream_seq_exhaustion_test.h
@@ -1,0 +1,8 @@
+#ifndef _UNABTO_STREAM_SEQ_EXHAUSTION_TEST_H_
+#define _UNABTO_STREAM_SEQ_EXHAUSTION_TEST_H_
+
+#include <unabto/unabto_env_base.h>
+
+bool unabto_stream_seq_exhaustion_test(void);
+
+#endif

--- a/test/unabto/unabto_stream_window_test.c
+++ b/test/unabto/unabto_stream_window_test.c
@@ -40,7 +40,7 @@ bool unabto_stream_create_sack_pairs_test() {
     init_rbuf(tcb, 241);
 
     struct nabto_stream_sack_data sackData;
-    if (!unabto_stream_create_sack_pairs(&stream, &sackData)) {
+    if (!unabto_stream_create_sack_pairs(tcb, &sackData)) {
         return false;
     }
 

--- a/test/unabto/unabto_test.c
+++ b/test/unabto/unabto_test.c
@@ -17,6 +17,7 @@
 #include "util/unabto_util_test.h"
 #include "util/unabto_buffer_test.h"
 #include "unabto_stream_event_test.h"
+#include "unabto_stream_seq_exhaustion_test.h"
 #include "unabto_stream_window_test.h"
 #include "modules/util/unabto_base32_test.h"
 #include <unabto/unabto_stream_event_test.h>
@@ -133,6 +134,12 @@ bool unabto_test_all(void) {
     r = unabto_stream_create_sack_pairs_test();
     if (!r) {
         NABTO_LOG_ERROR(("Test of unabto stream create sack pairs failed."));
+        ret = false;
+    }
+
+    r = unabto_stream_seq_exhaustion_test();
+    if (!r) {
+        NABTO_LOG_ERROR(("Test of unabto stream seq exhaustion threshold failed."));
         ret = false;
     }
 


### PR DESCRIPTION
Instead of having SP and CP ID being shared for all streams and wrapping around, they are now bound to a session. Further they can no longer wrap around, removing a replay attack vector.
Further the 32bit stream sequence number was also susceptible to replayes once the window wrapped at 2^32 packets. This vector has also been fixed by capping the max packets on a stream